### PR TITLE
Unwind callable spin observables.

### DIFF
--- a/python/tdg/docs/computational-narrative/observables.rst
+++ b/python/tdg/docs/computational-narrative/observables.rst
@@ -89,6 +89,7 @@ By translation invariance these may be reduced to a function of one space variab
 .. autofunction:: tdg.observable.nn.nn
 .. autofunction:: tdg.observable.nn.density_density_fluctuations
 .. autofunction:: tdg.observable.ss.ss
+.. autofunction:: tdg.observable.ss.spin_spin_fluctuations
 .. autofunction:: tdg.observable.current.current_current
 .. autofunction:: tdg.observable.vorticity.vorticity_vorticity
 

--- a/python/tdg/docs/examples/analysis.ipynb
+++ b/python/tdg/docs/examples/analysis.ipynb
@@ -153,10 +153,9 @@
     "viz = visualize.History(3)\n",
     "viz.plot(ensemble.S.real, 0)\n",
     "viz.plot(ensemble.N('bosonic').real, 1)\n",
-    "viz.plot(ensemble.Spin(0).real, 1) # Another way of calculating N('fermionic')\n",
-    "viz.plot(ensemble.Spin(1).real, 2)\n",
-    "viz.plot(ensemble.Spin(2).real, 2)\n",
-    "viz.plot(ensemble.Spin(3).real, 2)"
+    "viz.plot(ensemble.Spin[...,0].real, 2)\n",
+    "viz.plot(ensemble.Spin[...,1].real, 2)\n",
+    "viz.plot(ensemble.Spin[...,2].real, 2)"
    ]
   },
   {
@@ -241,18 +240,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viz = visualize.History(5)\n",
+    "viz = visualize.History(4)\n",
     "viz.plot(ensemble.S.real, 0)\n",
     "viz.plot(ensemble.N('bosonic').real, 1)\n",
-    "viz.plot(ensemble.Spin(0).real, 2) # Another way of calculating N('fermionic')\n",
-    "viz.plot(ensemble.Spin(1).real, 3)\n",
-    "viz.plot(ensemble.Contact('fermionic').real, 4)\n",
+    "viz.plot(ensemble.Spin[...,0].real, 2)\n",
+    "viz.plot(ensemble.Contact('fermionic').real, 3)\n",
     "\n",
     "viz.plot(binned.S.real, x=binned.index, row=0)\n",
     "viz.plot(binned.N('bosonic').real, x=binned.index, row=1)\n",
-    "viz.plot(binned.Spin(0).real, x=binned.index, row=2) # Another way of calculating N('fermionic')\n",
-    "viz.plot(binned.Spin(1).real, x=binned.index, row=3)\n",
-    "viz.plot(binned.Contact('fermionic').real, x=binned.index, row=4)"
+    "viz.plot(binned.Spin[...,0].real, x=binned.index, row=2)\n",
+    "viz.plot(binned.Contact('fermionic').real, x=binned.index, row=3)"
    ]
   },
   {

--- a/python/tdg/tdg/ensemble.py
+++ b/python/tdg/tdg/ensemble.py
@@ -449,8 +449,8 @@ class Sector(H5able):
         '''
         return self._reweight(
             self._grid(lambda n, s:
-                       torch.einsum('sc,s->c',
-                                    torch.stack((self.Canonical._term(n,s).Spin(i) for i in [1,2,3])),
+                       torch.einsum('cs,s->c',
+                                    (self.Canonical._term(n,s).Spin),
                                     self.Canonical.hhat)
                       ))
 
@@ -502,6 +502,7 @@ class Sector(H5able):
 
 def _demo(steps=100, **kwargs):
 
+    import tdg.ensemble
     import tdg.action
     S = tdg.action._demo(**kwargs)
 
@@ -511,16 +512,16 @@ def _demo(steps=100, **kwargs):
     hmc = HMC.MarkovChain(H, integrator)
 
     try:
-        ensemble = GrandCanonical(S).generate(steps, hmc, progress=kwargs['progress'])
+        ensemble = tdg.ensemble.GrandCanonical(S).generate(steps, hmc, progress=kwargs['progress'])
     except:
-        ensemble = GrandCanonical(S).generate(steps, hmc)
+        ensemble = tdg.ensemble.GrandCanonical(S).generate(steps, hmc)
 
     return ensemble
 
 if __name__ == '__main__':
     from tqdm import tqdm
+    import tdg, tdg.observable
     torch.set_default_dtype(torch.float64)
     ensemble = _demo(progress=tqdm)
     print(f"The fermionic estimator for the total particle number is {ensemble.N('fermionic').mean():+.4f}")
     print(f"The bosonic   estimator for the total particle number is {ensemble.N('bosonic'  ).mean():+.4f}")
-    print(f"The Spin(0)   estimator for the total particle number is {ensemble.Spin(0).mean()       :+.4f}")

--- a/python/tdg/tdg/observable/energy.py
+++ b/python/tdg/tdg/observable/energy.py
@@ -58,7 +58,5 @@ def FreeEnergy(ensemble):
 
           - ensemble.Action.mu * ensemble.N('fermionic')
 
-          - ensemble.Action.h[0] * ensemble.Spin(1)
-          - ensemble.Action.h[1] * ensemble.Spin(2)
-          - ensemble.Action.h[2] * ensemble.Spin(3)
+          - torch.einsum('i,ci->c', 0.j+ensemble.Action.h, ensemble.Spin)
             )

--- a/python/tdg/tdg/observable/spin.py
+++ b/python/tdg/tdg/observable/spin.py
@@ -7,77 +7,24 @@ from tdg.observable import observable
 ####
 
 @observable
-def _spin(ensemble):
+def spin(ensemble):
     r'''
     The local spin density.
-    Direction slowest, then configurations, then sites.  That makes it easy to do something with ``ensemble.s[1]``.
-
-    .. note ::
-        The indices on the spins match the indices on :data:`tdg.PauliMatrix`.
-        The ``[0]`` entry matches ``ensemble.n('fermionic')``, a useful check.
+    Configurations, then sites, then spin direction.  That makes it easy to do something with :code:`ensemble.s[...,1]`.
+    The spin direction matches the index of :code:`tdg.PauliMatrix[1:]` so that :code:`0` is in the x direction, for example.
     '''
 
-    dt   = ensemble.Action.dt
-    hhat = ensemble.Action.hhat + 0j
-    absh = ensemble.Action.absh + 0j
-    
-    if absh == 0.:
-        Pspin = torch.diag(torch.tensor((0,0,0.5))) + 0j
-    else:
-        Pspin = (
-            0.5 * torch.outer(hhat,hhat)
-            # sinh(x/2) * cosh(x/2) = 0.5 * sinh(x)
-            + 0.5*torch.sinh(dt*absh) / (dt * absh) * (torch.eye(3) - torch.outer(hhat,hhat)) 
-            # sinh^2(x/2) = 1/2 * (cosh(x) - 1)
-            + 0.5j * (torch.cosh(0.5*dt*absh)-1) / (dt * absh) * torch.einsum('ijk,j->ik', tdg.epsilon + 0j, hhat)
-           )
-    
-    # expand to include 'all four' "spin" matrices.
-    Pspin = torch.nn.ConstantPad2d((1,0,1,0), 0)(Pspin)
-    Pspin[0,0] = 1.
-    # and construct a vector of paulis.
-    Pspin = torch.einsum('ik,kab->iab', Pspin, tdg.PauliMatrix)
-    
-    return torch.einsum('cxxab,iba->icx', ensemble.G, Pspin)
+    return torch.einsum('cxxst,ist->cxi', ensemble.G, 0.5 * tdg.PauliMatrix[1:] + 0.j)
 
-@observable
-def spin(ensemble, direction):
-    r'''
-    The local spin density.  Configurations, then sites.
-    
-    Parameters
-    ----------
-        direction: int
-            An integer indexing the spin direction, which matches the index of :data:`tdg.PauliMatrix`.  :code:`0` is equal to :code:`n('fermionic')`.
-    
-    Returns
-    -------
-        torch.tensor
-    '''
-    return ensemble._spin[direction]
-    
 ####
 #### Extensive
 ####
 
 @observable
-def _Spin(ensemble):
-    return ensemble._spin.sum(-1)
-
-@observable
-def Spin(ensemble, direction):
+def Spin(ensemble):
     r'''
-    The total spin, summed over sites.  One per configuration.
-    
-    Parameters
-    ----------
-        direction: int
-            An integer indexing the spin direction, which matches the index of :data:`tdg.PauliMatrix`.  :code:`0` is equal to :code:`N('fermionic')`.
-    
-    Returns
-    -------
-        torch.tensor
+    The total spin, summed over sites.  Configurations slowest, then spin direction.
+    The spin direction matches the index of :code:`tdg.PauliMatrix[1:]` so that :code:`0` is in the x direction, for example.
     '''
-    return ensemble._Spin[direction]
-
+    return ensemble.spin.sum(axis=1)
 

--- a/python/tdg/tdg/observable/ss.py
+++ b/python/tdg/tdg/observable/ss.py
@@ -1,6 +1,6 @@
 import torch
 import tdg
-from tdg.observable import observable
+from tdg.observable import observable, derived
 
 @observable
 def ss(ensemble):
@@ -8,19 +8,22 @@ def ss(ensemble):
     The (spatial) convolution of :math:`s^i * s^j`, which plays an important role in spin-spin fluctuation correlators.
 
     Configurations slowest, then (linearized) sites, then i, then j.
+
+    .. todo::
+       The convolution may be fourier accelerated.
     '''
 
     L = ensemble.Action.Spacetime.Lattice
 
     c = (
     # 1/4 δ_ab δ^ij < n_a >
+    # nb: this takes the spatial average, by translation invariance
     + torch.einsum('c,ab,ij->cabij', ensemble.N('fermionic') , torch.eye(L.sites), torch.eye(3) / 4 / L.sites)
 
     + (
     # i/2 δ_ab ε^ijk < s^k_a >
-        + torch.einsum('ij,c,ab->cabij', 0.5j / L.sites * tdg.epsilon[:,:,0], ensemble.S(1), torch.eye(L.sites))
-        + torch.einsum('ij,c,ab->cabij', 0.5j / L.sites * tdg.epsilon[:,:,1], ensemble.S(2), torch.eye(L.sites))
-        + torch.einsum('ij,c,ab->cabij', 0.5j / L.sites * tdg.epsilon[:,:,2], ensemble.S(3), torch.eye(L.sites))
+    # nb: this takes the spatial average, by translation invariance
+        + torch.einsum('ijk,ck,ab->cabij', 0.5j / L.sites * tdg.epsilon, ensemble.Spin, torch.eye(L.sites))
         if (ensemble.Action.h != torch.tensor([0.,0.,0.])).all()
         else 0
     )
@@ -34,4 +37,19 @@ def ss(ensemble):
                         c,
                         L.convolver + 0.j
     )
+
+@derived
+def spin_spin_fluctuations(ensemble):
+    r'''
+    A derived quantity, :math:`\left\langle (e^i*s^j)_r \right\rangle - \left(\left\langle s^i \right\rangle * \left\langle s^j \right\rangle\right)_r`.
+
+    Bootstraps first, then relative coordinate :math:`r`.
+
+    .. todo::
+       The disconnected convolution may be fourier accelerated.
+    '''
+
+    L = ensemble.Action.Spacetime.Lattice
+
+    return ensemble.ss - torch.einsum('cai,cbj,bra->crij', ensemble.spin, ensemble.spin, 0.j+L.convolver)
 


### PR DESCRIPTION
It became less and less sustainable as I implemented more and more observables to have a non-uniform interface.  I anticipate removing callable nature of the fermion number as well, simply providing additional methods instead.