### PR TITLE
Bootstrapping can compute ensemble intermediates

### DIFF
--- a/python/tdg/tdg/analysis/bootstrap.py
+++ b/python/tdg/tdg/analysis/bootstrap.py
@@ -102,7 +102,7 @@ class Bootstrap(H5able):
     
     def __getattr__(self, name):
         
-        if name not in self._observables | self._intermediates:
+        if name not in self._observables | self._intermediates | self.Ensemble._intermediates :
             raise AttributeError(name)
 
         with Timer(logger.info, f'Bootstrapping {name}', per=len(self)):


### PR DESCRIPTION
I tried running

docs/sanity-checks/free-theory-{continuum,infinite-volume}-limit.ipynb

and found that I couldn't compute pairing observables because the bootstrap no longer had access to G.

G was marked @intermediate in #84, but in my trial production I was manually storing the propagator and therefore wasn't noticing this issue.

Intermediate quantities (typically) are not needed at the bootstrap level, but the propagator is an exception if you try to compute pairing matrix observables.  There's no reason I can think of, though, to make it *disallowed* for the bootstrap to compute the intermediate if it knows what it's doing.