### PR TITLE
Fix/rtd dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ sphinx:
 
 python:
   install:
+    - requirements: python/tdg/requirements.txt
     - method: pip
       path: python/tdg
   system_packages: true

--- a/python/tdg/pyproject.toml
+++ b/python/tdg/pyproject.toml
@@ -2,27 +2,11 @@
 
 name = "tdg"
 description = "Auxiliary field quantum monte carlo for 2D gasses"
-version = "0.0.0"
 authors = [
     { name = "Evan Berkowitz", email = "tdg@evanberkowitz.com" }
 ]
 
-dependencies = [
-    "torch>=1.13",
-    "functorch>=1.13",
-    "numpy>=1.21",
-    "scipy>=1.8",
-    "pandas>=1.4",
-    "h5py>=3.7",
-    "matplotlib>=3.5.2",
-    "tqdm>=4.64",
-    "sphinx-git==11.0.0",
-    "sphinx-rtd-theme==1.1.0",
-    "sphinxcontrib-bibtex==2.5.0",
-    "pybtex",
-    "pybtex-docutils",
-    "nbstripout",
-]
+dynamic = ["dependencies", "version"]
 
 [options]
 
@@ -33,3 +17,8 @@ install_requires = [
 py-modules = [
     "tdg",
 ]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+version = { attr = "tdg.meta.version" }

--- a/python/tdg/requirements.txt
+++ b/python/tdg/requirements.txt
@@ -1,0 +1,25 @@
+# MATH
+
+torch>=1.13
+functorch>=1.13
+numpy>=1.21
+scipy>=1.8
+
+# IO
+
+h5py>=3.7
+tqdm>=4.64
+pandas>=1.4
+
+# DOCS
+
+sphinx-git==11.0.0
+sphinx-rtd-theme==1.1.0
+sphinxcontrib-bibtex==2.5.0
+pybtex
+pybtex-docutils
+nbstripout
+
+# PLOTTING
+
+matplotlib>=3.5.2

--- a/python/tdg/tdg/meta.py
+++ b/python/tdg/tdg/meta.py
@@ -1,5 +1,5 @@
 name = "tdg"
-version = "0.0.0"
+version = "0.1.0"
 author = "Evan Berkowitz"
 author_email = "tdg@evanberkowitz.com"
 description = "Auxiliary field quantum monte carlo for 2D gasses"


### PR DESCRIPTION
rtd is deprecating the "use system packages" feature and therefore we need a requirements.txt file.